### PR TITLE
Add `notifyOnTouchEnd` property to trigger `notify` on `touchEnd` if the user didn't scroll

### DIFF
--- a/src/PageClick.js
+++ b/src/PageClick.js
@@ -9,18 +9,18 @@ const extractCoordinates = ({changedTouches}) =>
 const PageClick = React.createClass({
   propTypes: {
     children: React.PropTypes.node.isRequired,
-    onClick: React.PropTypes.func.isRequired,
+    notify: React.PropTypes.func.isRequired,
     onMouseDown: React.PropTypes.func,
     onTouchStart: React.PropTypes.func,
     outsideOnly: React.PropTypes.bool,
-    useEndEvent: React.PropTypes.bool
+    notifyOnTouchEnd: React.PropTypes.bool
   },
 
 
   getDefaultProps() {
     return {
       outsideOnly: true,
-      useEndEvent: false
+      notifyOnTouchEnd: false
     };
   },
 
@@ -28,20 +28,12 @@ const PageClick = React.createClass({
   componentWillMount() {
     this.insideClick = false;
     this.touchStart = null;
-    this.justCalledOnClick = false;
-    this.clickHandlerTimeout = null;
-    this.resetInsideClickTimeout = null;
-    this.resetJustCalledOnClickTimeout = null;
   },
 
 
   componentDidMount() {
     global.window.addEventListener('mousedown', this.onDocumentMouseDown, false);
-    global.window.addEventListener('mouseup', this.resetInsideClick, false);
-    // if this component is mounting because of a click event, then that event can still get
-    // captured by this listener unless we wait
-    this.clickHandlerTimeout = setTimeout(() =>
-      window.addEventListener('click', this.onDocumentClick, false));
+    global.window.addEventListener('mouseup', this.onDocumentMouseUp, false);
     global.window.addEventListener('touchstart', this.onDocumentTouchStart, false);
     global.window.addEventListener('touchend', this.onDocumentTouchEnd, false);
   },
@@ -51,22 +43,23 @@ const PageClick = React.createClass({
 
 
   componentWillUnmount() {
-    clearTimeout(this.clickHandlerTimeout);
-    clearTimeout(this.resetInsideClickTimeout);
-    clearTimeout(this.resetJustCalledOnClickTimeout);
     global.window.removeEventListener('mousedown', this.onDocumentMouseDown, false);
-    global.window.removeEventListener('mouseup', this.resetInsideClick, false);
-    global.window.removeEventListener('click', this.onDocumentClick, false);
+    global.window.removeEventListener('mouseup', this.onDocumentMouseUp, false);
     global.window.removeEventListener('touchstart', this.onDocumentTouchStart, false);
     global.window.removeEventListener('touchend', this.onDocumentTouchEnd, false);
   },
 
 
   onDocumentMouseDown(...args) {
-    if (this.insideClick || this.props.useEndEvent) {
+    if (this.insideClick || this.props.notifyOnTouchEnd) {
       return;
     }
-    this.props.onClick(...args);
+    this.props.notify(...args);
+  },
+
+
+  onDocumentMouseUp() {
+    this.insideClick = false;
   },
 
 
@@ -74,53 +67,29 @@ const PageClick = React.createClass({
     if (this.insideClick) {
       return;
     }
-    if (this.props.useEndEvent) {
+    if (this.props.notifyOnTouchEnd) {
       this.touchStart = extractCoordinates(event);
     } else {
-      this.props.onClick(event, ...args);
-    }
-  },
-
-
-  resetInsideClick() {
-    if (this.props.useEndEvent) {
-      // we don't want to reset insideClick until after onDocumentMouseClick has been triggered
-      this.resetInsideClickTimeout = setTimeout(() => {
-        this.insideClick = false;
-      });
-    } else {
-      this.insideClick = false;
-    }
-  },
-
-
-  onDocumentClick(...args) {
-    if (this.props.useEndEvent && !this.insideClick && !this.justCalledOnClick) {
-      this.props.onClick(...args);
+      this.props.notify(event, ...args);
     }
   },
 
 
   onDocumentTouchEnd(event, ...args) {
-    this.resetInsideClick();
     // on mobile safari click events are not bubbled up to the document unless the target has the
     // css `cursor: pointer;` http://www.quirksmode.org/blog/archives/2010/10/click_event_del_1.html
-    // so try and work out if we should call the onClick prop, on other browsers, onDocumentClick
-    // will get called, so use a 'justCalledOnClick' flag to prevent calling onClick twice
-    if (this.props.useEndEvent && this.touchStart && !this.insideClick) {
+    // so try and work out if we should call the notify prop
+    if (this.props.notifyOnTouchEnd && this.touchStart && !this.insideClick) {
       const {x, y} = extractCoordinates(event);
       const dx = Math.abs(x - this.touchStart.x);
       const dy = Math.abs(y - this.touchStart.y);
 
       if (dx < MAX_MOVE && dy < MAX_MOVE) {
-        this.props.onClick(event, ...args);
-        this.justCalledOnClick = true;
-        this.resetJustCalledOnClickTimeout = setTimeout(() => {
-          this.justCalledOnClick = false;
-        });
+        this.props.notify(event, ...args);
       }
     }
     this.touchStart = null;
+    this.insideClick = false;
   },
 
 

--- a/src/PageClick.js
+++ b/src/PageClick.js
@@ -1,6 +1,7 @@
 import React from 'react';
 import {shouldComponentUpdate} from 'react/lib/ReactComponentWithPureRenderMixin';
 
+const MAX_MOVE = 20;
 
 const PageClick = React.createClass({
   propTypes: {
@@ -8,27 +9,34 @@ const PageClick = React.createClass({
     onClick: React.PropTypes.func.isRequired,
     onMouseDown: React.PropTypes.func,
     onTouchStart: React.PropTypes.func,
-    outsideOnly: React.PropTypes.bool
+    outsideOnly: React.PropTypes.bool,
+    useEndEvent: React.PropTypes.bool
   },
 
 
   getDefaultProps() {
     return {
-      outsideOnly: true
+      outsideOnly: true,
+      useEndEvent: false
     };
   },
 
 
   componentWillMount() {
     this.insideClick = false;
+    this.touchStart = null;
+    this.justCalledOnClick = false;
   },
 
 
   componentDidMount() {
-    global.window.addEventListener('touchstart', this.onDocumentClick, false);
-    global.window.addEventListener('touchend', this.onDocumentMouseUp, false);
-    global.window.addEventListener('mousedown', this.onDocumentClick, false);
-    global.window.addEventListener('mouseup', this.onDocumentMouseUp, false);
+    global.window.addEventListener('mousedown', this.onStartEvent, false);
+    global.window.addEventListener('mouseup', this.resetInsideClick, false);
+    // if this component is mounting because of a click event, then that event can still get
+    // captured by this listener unless we wait
+    setTimeout(() => window.addEventListener('click', this.onDocumentClick, false));
+    global.window.addEventListener('touchstart', this.onStartEvent, false);
+    global.window.addEventListener('touchend', this.onDocumentTouchEnd, false);
   },
 
 
@@ -36,23 +44,66 @@ const PageClick = React.createClass({
 
 
   componentWillUnmount() {
-    global.window.removeEventListener('touchstart', this.onDocumentClick, false);
-    global.window.removeEventListener('touchend', this.onDocumentMouseUp, false);
-    global.window.removeEventListener('mousedown', this.onDocumentClick, false);
-    global.window.removeEventListener('mouseup', this.onDocumentMouseUp, false);
+    global.window.removeEventListener('mousedown', this.onStartEvent, false);
+    global.window.removeEventListener('mouseup', this.resetInsideClick, false);
+    global.window.removeEventListener('click', this.onDocumentClick, false);
+    global.window.removeEventListener('touchstart', this.onStartEvent, false);
+    global.window.removeEventListener('touchend', this.onDocumentTouchEnd, false);
+  },
+
+
+  onStartEvent(event, ...args) {
+    if (this.insideClick) {
+      return;
+    }
+    if (this.props.useEndEvent) {
+      // if this event has touches, then save the first one
+      this.touchStart = event.touches ? event.touches[0] : null;
+    } else {
+      this.props.onClick(event, ...args);
+    }
+  },
+
+
+  resetInsideClick() {
+    if (this.props.useEndEvent) {
+      // we don't want to reset insideClick until after onDocumentMouseClick has been triggered
+      setTimeout(() => {
+        this.insideClick = false;
+      });
+    } else {
+      this.insideClick = false;
+    }
   },
 
 
   onDocumentClick(...args) {
-    if (this.insideClick) {
-      return;
+    if (this.props.useEndEvent && !this.insideClick && !this.justCalledOnClick) {
+      this.props.onClick(...args);
     }
-    this.props.onClick(...args);
   },
 
 
-  onDocumentMouseUp() {
-    this.insideClick = false;
+  onDocumentTouchEnd(event, ...args) {
+    this.resetInsideClick();
+    // on mobile safari click events are not bubbled up to the document unless the target has the
+    // css `cursor: pointer;` http://www.quirksmode.org/blog/archives/2010/10/click_event_del_1.html
+    // so try and work out if we should call the onClick prop, on other browsers, onDocumentClick
+    // will get called, so use a 'justCalledOnClick' flag to prevent calling onClick twice
+    if (this.props.useEndEvent && this.touchStart && !this.insideClick) {
+      const {clientX, clientY} = event.changedTouches[0];
+      const dx = Math.abs(clientX - this.touchStart.clientX);
+      const dy = Math.abs(clientY - this.touchStart.clientY);
+
+      if (dx < MAX_MOVE && dy < MAX_MOVE) {
+        this.props.onClick(event, ...args);
+        this.justCalledOnClick = true;
+        setTimeout(() => {
+          this.justCalledOnClick = false;
+        });
+      }
+    }
+    this.touchStart = null;
   },
 
 

--- a/src/example/App/Modal.js
+++ b/src/example/App/Modal.js
@@ -34,16 +34,16 @@ const styles = {
 const Modal = React.createClass({
   propTypes: {
     onClose: React.PropTypes.func.isRequired,
-    useEndEvent: React.PropTypes.bool
+    notifyOnTouchEnd: React.PropTypes.bool
   },
 
   render() {
-    const {onClose, useEndEvent, ...props} = this.props;
+    const {onClose, notifyOnTouchEnd, ...props} = this.props;
 
     return (
       <div>
         <div style={styles.shade} />
-        <PageClick onClick={onClose} useEndEvent={useEndEvent}>
+        <PageClick notify={onClose} notifyOnTouchEnd={notifyOnTouchEnd}>
           <div style={styles.popup}>
             <div style={styles.content} {...props} />
           </div>

--- a/src/example/App/Modal.js
+++ b/src/example/App/Modal.js
@@ -33,16 +33,17 @@ const styles = {
 
 const Modal = React.createClass({
   propTypes: {
-    onClose: React.PropTypes.func.isRequired
+    onClose: React.PropTypes.func.isRequired,
+    useEndEvent: React.PropTypes.bool
   },
 
   render() {
-    const {onClose, ...props} = this.props;
+    const {onClose, useEndEvent, ...props} = this.props;
 
     return (
       <div>
         <div style={styles.shade} />
-        <PageClick onClick={this.props.onClose}>
+        <PageClick onClick={onClose} useEndEvent={useEndEvent}>
           <div style={styles.popup}>
             <div style={styles.content} {...props} />
           </div>

--- a/src/example/App/index.js
+++ b/src/example/App/index.js
@@ -48,7 +48,7 @@ const App = React.createClass({
         <button onClick={this.showLazyModal}>
           Open Lazy Model
         </button>
-        &nbsp;Closes on mouse up or touch end events
+        &nbsp;Closes on mouse down or touch end events
 
         {showModal ? (
           <Modal onClose={this.hideModal}>
@@ -57,7 +57,7 @@ const App = React.createClass({
         ) : null}
 
         {showLazyModal ? (
-          <Modal onClose={this.hideLazyModal} useEndEvent>
+          <Modal onClose={this.hideLazyModal} notifyOnTouchEnd>
             Lazy Modal content
           </Modal>
         ) : null}

--- a/src/example/App/index.js
+++ b/src/example/App/index.js
@@ -6,7 +6,8 @@ import {name} from '../../../package.json';
 const App = React.createClass({
   getInitialState() {
     return {
-      showModal: false
+      showModal: false,
+      showLazyModal: false
     };
   },
 
@@ -21,8 +22,17 @@ const App = React.createClass({
   },
 
 
+  showLazyModal() {
+    this.setState({showLazyModal: true});
+  },
+
+
+  hideLazyModal() {
+    this.setState({showLazyModal: false});
+  },
+
   render() {
-    const {showModal} = this.state;
+    const {showModal, showLazyModal} = this.state;
 
     return (
       <div>
@@ -31,10 +41,24 @@ const App = React.createClass({
         <button onClick={this.showModal}>
           Open Modal
         </button>
+        &nbsp;Closes on mouse down or touch start events
+
+        <br />
+
+        <button onClick={this.showLazyModal}>
+          Open Lazy Model
+        </button>
+        &nbsp;Closes on mouse up or touch end events
 
         {showModal ? (
           <Modal onClose={this.hideModal}>
             Modal content
+          </Modal>
+        ) : null}
+
+        {showLazyModal ? (
+          <Modal onClose={this.hideLazyModal} useEndEvent>
+            Lazy Modal content
           </Modal>
         ) : null}
       </div>

--- a/test/PageClick-test.js
+++ b/test/PageClick-test.js
@@ -18,7 +18,7 @@ describe('PageClick', () => {
 
 
   it('should require the only child to be present', () => {
-    expect(() => TestUtils.renderIntoDocument(<PageClick onClick={() => {}} />))
+    expect(() => TestUtils.renderIntoDocument(<PageClick notify={() => {}} />))
       .toThrow();
   });
 
@@ -31,7 +31,7 @@ describe('PageClick', () => {
 
 
     it('should subscribe to mousedown on render', () => {
-      TestUtils.renderIntoDocument(<PageClick onClick={() => {}}><span>Test</span></PageClick>);
+      TestUtils.renderIntoDocument(<PageClick notify={() => {}}><span>Test</span></PageClick>);
 
       expect(global.window.addEventListener).toHaveBeenCalled();
       expect(global.window.addEventListener.calls.mostRecent().args[0]).toEqual('mousedown');
@@ -41,7 +41,7 @@ describe('PageClick', () => {
     it('should unsubscribe on destroy', () => {
       const div = document.createElement('div');
 
-      React.render(<PageClick onClick={() => {}}><span>Test</span></PageClick>, div);
+      React.render(<PageClick notify={() => {}}><span>Test</span></PageClick>, div);
 
       const onMouseDown = global.window.addEventListener.calls.mostRecent().args[1];
 
@@ -56,13 +56,13 @@ describe('PageClick', () => {
 
 
   describe('Notification on clicks', () => {
-    let pageClick, onClick, onMouseDown;
+    let pageClick, notify, onMouseDown;
 
     beforeEach(() => {
       spyOn(global.window, 'addEventListener');
-      onClick = jasmine.createSpy('onClick');
+      notify = jasmine.createSpy('notify');
       pageClick = TestUtils.renderIntoDocument(
-        <PageClick onClick={onClick}><span>Test</span></PageClick>);
+        <PageClick notify={notify}><span>Test</span></PageClick>);
       onMouseDown = global.window.addEventListener.calls.mostRecent().args[1];
     });
 
@@ -70,7 +70,7 @@ describe('PageClick', () => {
     it('should notify on clicks outside of the element', () => {
       onMouseDown();
 
-      expect(onClick).toHaveBeenCalled();
+      expect(notify).toHaveBeenCalled();
     });
 
 
@@ -80,7 +80,7 @@ describe('PageClick', () => {
       TestUtils.Simulate.mouseDown(span);
       onMouseDown();
 
-      expect(onClick).not.toHaveBeenCalled();
+      expect(notify).not.toHaveBeenCalled();
     });
 
 
@@ -106,19 +106,19 @@ describe('PageClick', () => {
     it('should pass-through click event and other arguments', () => {
       onMouseDown(1, 2, 3);
 
-      expect(onClick).toHaveBeenCalledWith(1, 2, 3);
+      expect(notify).toHaveBeenCalledWith(1, 2, 3);
     });
   });
 
 
   describe('Notification on clicks including clicks inside', () => {
-    let pageClick, onClick, onMouseDown;
+    let pageClick, notify, onMouseDown;
 
     beforeEach(() => {
       spyOn(global.window, 'addEventListener');
-      onClick = jasmine.createSpy('onClick');
+      notify = jasmine.createSpy('notify');
       pageClick = TestUtils.renderIntoDocument(
-        <PageClick onClick={onClick} outsideOnly={false}><span>Test</span></PageClick>);
+        <PageClick notify={notify} outsideOnly={false}><span>Test</span></PageClick>);
       onMouseDown = global.window.addEventListener.calls.mostRecent().args[1];
     });
 
@@ -129,7 +129,7 @@ describe('PageClick', () => {
       TestUtils.Simulate.mouseDown(span);
       onMouseDown();
 
-      expect(onClick).toHaveBeenCalled();
+      expect(notify).toHaveBeenCalled();
     });
   });
 });

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -4,6 +4,8 @@
 const webpack = require('webpack');
 const HtmlWebpackPlugin = require('html-webpack-plugin');
 const path = require('path');
+const host = process.env.NODE_HOST || 'localhost';
+const port = process.env.NODE_PORT || 8080;
 
 
 const loaders = [
@@ -37,7 +39,7 @@ const development = {
 
   entry: [
     './src/example/Example.js',
-    'webpack-dev-server/client?http://localhost:8080'
+    `webpack-dev-server/client?http://${host}:${port}`
   ],
   output: {filename: 'bundle.js', path: path.resolve('example')},
   plugins: [
@@ -53,6 +55,8 @@ const development = {
   resolve,
   stats,
   devServer: {
+    host,
+    port,
     historyApiFallback: true,
     stats: {
       // Do not show list of hundreds of files included in a bundle


### PR DESCRIPTION
Real pain with mobile safari not bubbling click events.

In the example, if `notifyOnTouchEnd` is set, when scrolling or zooming on a touch device, the modal is not dismissed.

Also use `NODE_HOST` and `NODE_PORT` env vars to allow testing on other devices on the same LAN.
